### PR TITLE
chore(tests): enhance test coverage for struct to map conversion

### DIFF
--- a/go-struct-utils/utils_test.go
+++ b/go-struct-utils/utils_test.go
@@ -46,6 +46,50 @@ type NestedStruct struct {
 	Count  int    `json:"count"`
 }
 
+// Additional test structs for better coverage
+type StructWithComplexTags struct {
+	Name        string  `json:"name,omitempty"`
+	Age         int     `json:"age,omitempty"`
+	Score       float64 `json:"score,omitempty"`
+	IsActive    bool    `json:"is_active,omitempty"`
+	Description string  `json:"description,omitempty"`
+}
+
+type StructWithEmptyJSONTag struct {
+	Name string `json:""`
+	Age  int    `json:""`
+}
+
+type StructWithOnlyCommaTag struct {
+	Name string `json:",omitempty"`
+	Age  int    `json:","`
+}
+
+type StructWithVariousTypes struct {
+	StringField    string         `json:"string_field"`
+	IntField       int            `json:"int_field"`
+	FloatField     float64        `json:"float_field"`
+	BoolField      bool           `json:"bool_field"`
+	SliceField     []string       `json:"slice_field"`
+	MapField       map[string]int `json:"map_field"`
+	InterfaceField interface{}    `json:"interface_field"`
+	PointerField   *string        `json:"pointer_field"`
+}
+
+type CircularA struct {
+	Name string     `json:"name"`
+	B    *CircularB `json:"b"`
+}
+
+type CircularB struct {
+	Name string     `json:"name"`
+	A    *CircularA `json:"a"`
+}
+
+type UnmarshalableStruct struct {
+	Channel chan int `json:"channel"`
+}
+
 func mapsEqual(a, b map[string]any) bool {
 	if len(a) != len(b) {
 		return false
@@ -156,6 +200,56 @@ func TestStructToMapJSON(t *testing.T) {
 				},
 				"count": float64(5),
 			},
+		},
+		{
+			name: "Struct with various types",
+			input: StructWithVariousTypes{
+				StringField:    "test",
+				IntField:       42,
+				FloatField:     3.14,
+				BoolField:      true,
+				SliceField:     []string{"a", "b", "c"},
+				MapField:       map[string]int{"key1": 1, "key2": 2},
+				InterfaceField: "interface_value",
+				PointerField:   stringPtr("pointer_value"),
+			},
+			expected: map[string]any{
+				"string_field":    "test",
+				"int_field":       float64(42),
+				"float_field":     3.14,
+				"bool_field":      true,
+				"slice_field":     []interface{}{"a", "b", "c"},
+				"map_field":       map[string]interface{}{"key1": float64(1), "key2": float64(2)},
+				"interface_field": "interface_value",
+				"pointer_field":   "pointer_value",
+			},
+		},
+		{
+			name: "Struct with nil pointer field",
+			input: StructWithVariousTypes{
+				StringField:  "test",
+				PointerField: nil,
+			},
+			expected: map[string]any{
+				"string_field":    "test",
+				"int_field":       float64(0),
+				"float_field":     float64(0),
+				"bool_field":      false,
+				"slice_field":     nil,
+				"map_field":       nil,
+				"interface_field": nil,
+				"pointer_field":   nil,
+			},
+		},
+		{
+			name:        "Unmarshalable struct with channel",
+			input:       UnmarshalableStruct{Channel: make(chan int)},
+			expectError: true,
+		},
+		{
+			name:     "Nil input",
+			input:    nil,
+			expected: nil,
 		},
 	}
 
@@ -271,6 +365,55 @@ func TestStructToMapReflection(t *testing.T) {
 			input:    (*Person)(nil),
 			expected: map[string]any{},
 		},
+		{
+			name: "Struct with empty JSON tag",
+			input: StructWithEmptyJSONTag{
+				Name: "Test",
+				Age:  25,
+			},
+			expected: map[string]any{
+				"Name": "Test",
+				"Age":  25,
+			},
+		},
+		{
+			name: "Struct with various types",
+			input: StructWithVariousTypes{
+				StringField:    "test",
+				IntField:       42,
+				FloatField:     3.14,
+				BoolField:      true,
+				SliceField:     []string{"a", "b", "c"},
+				MapField:       map[string]int{"key1": 1, "key2": 2},
+				InterfaceField: "interface_value",
+				PointerField:   stringPtr("pointer_value"),
+			},
+			expected: map[string]any{
+				"string_field":    "test",
+				"int_field":       42,
+				"float_field":     3.14,
+				"bool_field":      true,
+				"slice_field":     []string{"a", "b", "c"},
+				"map_field":       map[string]int{"key1": 1, "key2": 2},
+				"interface_field": "interface_value",
+				"pointer_field":   stringPtr("pointer_value"),
+			},
+		},
+		{
+			name:     "Integer input",
+			input:    42,
+			expected: map[string]any{},
+		},
+		{
+			name:     "Slice input",
+			input:    []string{"a", "b", "c"},
+			expected: map[string]any{},
+		},
+		{
+			name:     "Map input",
+			input:    map[string]int{"key": 1},
+			expected: map[string]any{},
+		},
 	}
 
 	for _, tt := range tests {
@@ -371,6 +514,93 @@ func TestStructToMapReflectionAdvanced(t *testing.T) {
 			input:    (*Person)(nil),
 			expected: map[string]any{},
 		},
+		{
+			name: "Struct with empty JSON tag",
+			input: StructWithEmptyJSONTag{
+				Name: "Test",
+				Age:  25,
+			},
+			expected: map[string]any{
+				"Name": "Test",
+				"Age":  25,
+			},
+		},
+		{
+			name: "Struct with comma-only JSON tag",
+			input: StructWithOnlyCommaTag{
+				Name: "Test",
+				Age:  25,
+			},
+			expected: map[string]any{
+				"Name": "Test",
+				"Age":  25,
+			},
+		},
+		{
+			name: "Struct with complex JSON tags",
+			input: StructWithComplexTags{
+				Name:        "Test",
+				Age:         25,
+				Score:       95.5,
+				IsActive:    true,
+				Description: "A test description",
+			},
+			expected: map[string]any{
+				"name":        "Test",
+				"age":         25,
+				"score":       95.5,
+				"is_active":   true,
+				"description": "A test description",
+			},
+		},
+		{
+			name: "Struct with various types",
+			input: StructWithVariousTypes{
+				StringField:    "test",
+				IntField:       42,
+				FloatField:     3.14,
+				BoolField:      true,
+				SliceField:     []string{"a", "b", "c"},
+				MapField:       map[string]int{"key1": 1, "key2": 2},
+				InterfaceField: "interface_value",
+				PointerField:   stringPtr("pointer_value"),
+			},
+			expected: map[string]any{
+				"string_field":    "test",
+				"int_field":       42,
+				"float_field":     3.14,
+				"bool_field":      true,
+				"slice_field":     []string{"a", "b", "c"},
+				"map_field":       map[string]int{"key1": 1, "key2": 2},
+				"interface_field": "interface_value",
+				"pointer_field":   stringPtr("pointer_value"),
+			},
+		},
+		{
+			name:     "Integer input",
+			input:    42,
+			expected: map[string]any{},
+		},
+		{
+			name:     "Slice input",
+			input:    []string{"a", "b", "c"},
+			expected: map[string]any{},
+		},
+		{
+			name:     "Map input",
+			input:    map[string]int{"key": 1},
+			expected: map[string]any{},
+		},
+		{
+			name:     "Interface input",
+			input:    interface{}("test"),
+			expected: map[string]any{},
+		},
+		{
+			name:     "Function input",
+			input:    func() {},
+			expected: map[string]any{},
+		},
 	}
 
 	for _, tt := range tests {
@@ -382,4 +612,160 @@ func TestStructToMapReflectionAdvanced(t *testing.T) {
 			}
 		})
 	}
+}
+
+// Test edge cases for JSON tag parsing in basic reflection
+func TestStructToMapReflectionJSONTagParsing(t *testing.T) {
+	type TestStruct struct {
+		Field1 string `json:"field1,omitempty"`
+		Field2 string `json:"field2,omitempty,string"`
+		Field3 string `json:"field3"`
+		Field4 string `json:",omitempty"`
+		Field5 string `json:""`
+		Field6 string // no tag
+	}
+
+	input := TestStruct{
+		Field1: "value1",
+		Field2: "value2",
+		Field3: "value3",
+		Field4: "value4",
+		Field5: "value5",
+		Field6: "value6",
+	}
+
+	result := StructToMapUsingReflection(input)
+	expected := map[string]any{
+		"field1": "value1",
+		"field2": "value2",
+		"field3": "value3",
+		"":       "value4", // comma-only tag results in empty string key
+		"Field5": "value5", // empty tag should use field name
+		"Field6": "value6", // no tag should use field name
+	}
+
+	if !mapsEqual(result, expected) {
+		t.Errorf("Expected %+v, got %+v", expected, result)
+	}
+}
+
+// Test edge cases for JSON tag parsing in advanced reflection
+func TestStructToMapAdvancedReflectionJSONTagParsing(t *testing.T) {
+	type TestStruct struct {
+		Field1 string `json:"field1,omitempty"`
+		Field2 string `json:"field2,omitempty,string"`
+		Field3 string `json:"field3"`
+		Field4 string `json:",omitempty"`
+		Field5 string `json:""`
+		Field6 string // no tag
+		Field7 string `json:"field7,omitempty,required"`
+	}
+
+	input := TestStruct{
+		Field1: "value1",
+		Field2: "value2",
+		Field3: "value3",
+		Field4: "value4",
+		Field5: "value5",
+		Field6: "value6",
+		Field7: "value7",
+	}
+
+	result := StructToMapUsingAdvancedReflection(input)
+	expected := map[string]any{
+		"field1": "value1",
+		"field2": "value2",
+		"field3": "value3",
+		"Field4": "value4", // comma-only tag should use field name
+		"Field5": "value5", // empty tag should use field name
+		"Field6": "value6", // no tag should use field name
+		"field7": "value7",
+	}
+
+	if !mapsEqual(result, expected) {
+		t.Errorf("Expected %+v, got %+v", expected, result)
+	}
+}
+
+// Test nil pointer handling
+func TestNilPointerHandling(t *testing.T) {
+	var nilPerson *Person = nil
+	var nilInterface interface{} = nil
+
+	// Test JSON method
+	result1, err := StructToMapJSON(nilPerson)
+	if err != nil {
+		t.Errorf("StructToMapJSON with nil pointer should not error, got: %v", err)
+	}
+	if result1 != nil {
+		t.Errorf("StructToMapJSON with nil pointer should return nil, got: %+v", result1)
+	}
+
+	result2, err := StructToMapJSON(nilInterface)
+	if err != nil {
+		t.Errorf("StructToMapJSON with nil interface should not error, got: %v", err)
+	}
+	if result2 != nil {
+		t.Errorf("StructToMapJSON with nil interface should return nil, got: %+v", result2)
+	}
+
+	// Test reflection methods
+	result3 := StructToMapUsingReflection(nilPerson)
+	expected := map[string]any{}
+	if !mapsEqual(result3, expected) {
+		t.Errorf("StructToMapUsingReflection with nil pointer should return empty map, got: %+v", result3)
+	}
+
+	result4 := StructToMapUsingAdvancedReflection(nilPerson)
+	if !mapsEqual(result4, expected) {
+		t.Errorf("StructToMapUsingAdvancedReflection with nil pointer should return empty map, got: %+v", result4)
+	}
+}
+
+// Benchmark tests
+func BenchmarkStructToMapJSON(b *testing.B) {
+	person := Person{
+		Name:     "John Doe",
+		Age:      30,
+		Email:    "john@example.com",
+		IsActive: true,
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = StructToMapJSON(person)
+	}
+}
+
+func BenchmarkStructToMapUsingReflection(b *testing.B) {
+	person := Person{
+		Name:     "John Doe",
+		Age:      30,
+		Email:    "john@example.com",
+		IsActive: true,
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = StructToMapUsingReflection(person)
+	}
+}
+
+func BenchmarkStructToMapUsingAdvancedReflection(b *testing.B) {
+	person := Person{
+		Name:     "John Doe",
+		Age:      30,
+		Email:    "john@example.com",
+		IsActive: true,
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = StructToMapUsingAdvancedReflection(person)
+	}
+}
+
+// Helper function
+func stringPtr(s string) *string {
+	return &s
 }


### PR DESCRIPTION
Added additional test cases to improve the coverage of the `StructToMap` functions. This includes tests for various struct types with complex JSON tags, empty tags, and different data types. Also added edge case tests for JSON tag parsing and nil pointer handling. Benchmark tests were included to measure performance of different conversion methods. These changes aim to ensure robustness and reliability of the struct to map conversion logic.